### PR TITLE
Add random clustering baseline and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - '**.py'
+      - '.github/workflows/**'
+      - readme.md
+  pull_request:
+
+jobs:
+  run-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Test random clustering across all datasets
+        run: |
+          python eval_entrypoint.py --method random_clustering --all

--- a/eval_entrypoint.py
+++ b/eval_entrypoint.py
@@ -74,6 +74,9 @@ def eval_throughput(model_name):
     run(['python', 'throughput.py', '--model_name', model_name])
 
 
+def eval_random_clustering(dataset, seed):
+    run(['python', 'random_clustering.py', dataset, '--seed', str(seed)])
+
 def eval_custom(dataset, seed, script):
     cmd = ['python', script, dataset]
     if seed is not None:
@@ -85,7 +88,8 @@ def main():
     parser = argparse.ArgumentParser(description='Unified evaluation entrypoint')
     parser.add_argument('--method', required=True,
                         choices=['zeroer', 'ditto', 'unicorn', 'anymatch',
-                                 'matchgpt', 'jellyfish', 'throughput', 'custom'])
+                                 'matchgpt', 'jellyfish', 'throughput',
+                                 'random_clustering', 'custom'])
     parser.add_argument('--dataset', help='Dataset name for the evaluation')
     parser.add_argument('--all', action='store_true',
                         help='Run on all benchmark datasets')
@@ -123,6 +127,8 @@ def main():
             elif args.method == 'throughput':
                 model = args.model or 'anymatch-llama3'
                 eval_throughput(model)
+            elif args.method == 'random_clustering':
+                eval_random_clustering(dataset, seed)
             elif args.method == 'custom':
                 if not args.script:
                     parser.error('--script is required for custom method')

--- a/random_clustering.py
+++ b/random_clustering.py
@@ -1,0 +1,73 @@
+import argparse
+import csv
+import random
+from typing import Dict, List, Tuple
+
+DATASET_DIRS = {
+    'abt': 'abt_buy',
+    'amgo': 'amazon_google',
+    'beer': 'beer',
+    'dbac': 'dblp_acm',
+    'dbgo': 'dblp_scholar',
+    'foza': 'fodors_zagat',
+    'itam': 'itunes_amazon',
+    'roim': 'rotten_imdb',
+    'waam': 'walmart_amazon',
+    'wdc': 'wdc',
+    'zoye': 'zomato_yelp',
+}
+
+
+def load_pairs(dataset: str) -> List[Tuple[str, str, int]]:
+    dir_name = DATASET_DIRS.get(dataset, dataset)
+    path = f"data/raw/{dir_name}/test.csv"
+    pairs = []
+    try:
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                pairs.append((row["ltable_id"], row["rtable_id"], int(row["label"])) )
+    except FileNotFoundError:
+        return []
+    return pairs
+
+
+def random_clustering(dataset: str, seed: int = 42, clusters: int = 5) -> float:
+    pairs = load_pairs(dataset)
+    left_ids = {p[0] for p in pairs}
+    right_ids = {p[1] for p in pairs}
+
+    random.seed(seed)
+    left_clusters: Dict[str, int] = {lid: random.randrange(clusters) for lid in left_ids}
+    right_clusters: Dict[str, int] = {rid: random.randrange(clusters) for rid in right_ids}
+
+    preds: List[int] = []
+    labels: List[int] = []
+    for lid, rid, label in pairs:
+        pred = 1 if left_clusters[lid] == right_clusters[rid] else 0
+        preds.append(pred)
+        labels.append(label)
+
+    tp = sum(1 for p, l in zip(preds, labels) if p == l == 1)
+    fp = sum(1 for p, l in zip(preds, labels) if p == 1 and l == 0)
+    fn = sum(1 for p, l in zip(preds, labels) if p == 0 and l == 1)
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+    print(f"{dataset} seed={seed} f1={f1:.4f}")
+    return f1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Random clustering baseline")
+    parser.add_argument("dataset", help="Dataset name")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--clusters", type=int, default=5)
+    args = parser.parse_args()
+    random_clustering(args.dataset, args.seed, args.clusters)
+
+
+if __name__ == "__main__":
+    main()

--- a/random_clustering.py
+++ b/random_clustering.py
@@ -56,7 +56,11 @@ def random_clustering(dataset: str, seed: int = 42, clusters: int = 5) -> float:
     recall = tp / (tp + fn) if (tp + fn) else 0.0
     f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
 
-    print(f"{dataset} seed={seed} f1={f1:.4f}")
+    n_pairs = len(pairs)
+    n_pos = sum(labels)
+    expected_f1 = (2 * n_pos) / (n_pos * clusters + n_pairs) if n_pairs else 0.0
+
+    print(f"{dataset} seed={seed} f1={f1:.4f} expected={expected_f1:.4f}")
     return f1
 
 

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,15 @@ python eval_entrypoint.py --method zeroer --dataset abt --seed 42
 python eval_entrypoint.py --method anymatch --dataset dbgo --base_model llama3
 ```
 
+For lightweight experimentation or CI checks, a toy `random_clustering` method
+is provided. It predicts matches by randomly assigning records to clusters and
+computing the F1 score on the test pairs. You can run it on a single dataset or
+all datasets:
+```bash
+python eval_entrypoint.py --method random_clustering --dataset abt
+python eval_entrypoint.py --method random_clustering --all
+```
+
 To benchmark a new method on all datasets at once, pass the path to the
 script and use `--method custom --all`:
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -108,9 +108,9 @@ python eval_entrypoint.py --method anymatch --dataset dbgo --base_model llama3
 ```
 
 For lightweight experimentation or CI checks, a toy `random_clustering` method
-is provided. It predicts matches by randomly assigning records to clusters and
-computing the F1 score on the test pairs. You can run it on a single dataset or
-all datasets:
+is provided. It predicts matches by randomly assigning records to clusters. The
+script prints both the actual F1 score and the theoretical expectation based on
+the number of clusters. You can run it on a single dataset or all datasets:
 ```bash
 python eval_entrypoint.py --method random_clustering --dataset abt
 python eval_entrypoint.py --method random_clustering --all


### PR DESCRIPTION
## Summary
- implement a lightweight `random_clustering` baseline
- support `random_clustering` in `eval_entrypoint.py`
- document the new method
- add GitHub Action to exercise the `--all` flag

## Testing
- `python random_clustering.py abt`
- `python eval_entrypoint.py --method random_clustering --dataset abt --seeds 42`
- `python eval_entrypoint.py --method random_clustering --all --seeds 42`

------
https://chatgpt.com/codex/tasks/task_e_68647ba1d3dc8330b9ed8f99d5efdcef